### PR TITLE
Changed homeeToMqtt.service

### DIFF
--- a/homeeToMqtt.service
+++ b/homeeToMqtt.service
@@ -15,7 +15,7 @@ StandardOutput=syslog
 # Error to syslog:
 StandardError=syslog
 SyslogIdentifier=homeeToMqtt
-WorkingDirectory=/home/n/homeeToMqtt
+WorkingDirectory=/home/pi/homeeToMqtt
 User=pi
 #Group=<alternate group>
 Environment=NODE_ENV=production PORT=8000

--- a/homeeToMqtt.service
+++ b/homeeToMqtt.service
@@ -1,16 +1,24 @@
+[Unit]
+Description=Runs homeeToMqtt. Edit Service-File to enable reloading everytime Docker is started or restarted.
+#After=docker.service
+#BindsTo=docker.service
+#ReloadPropagatedFrom=docker.service
+
 [Service]
 #ExecStart=/home/pi/.nvm/versions/node/v8.9.4/bin/node /home/pi/homeeToMqtt/app.js
 ExecStart=/usr/bin/nodejs /home/pi/homeeToMqtt/app.js
 Restart=always
-RestartSec=10                       # Restart service after 10 seconds if node service crashes
-StandardOutput=syslog               # Output to syslog
-StandardError=syslog                # Output to syslog
+# Restart service after 10 seconds if node service crashes:
+RestartSec=10
+# Output to syslog:
+StandardOutput=syslog
+# Error to syslog:
+StandardError=syslog
 SyslogIdentifier=homeeToMqtt
-WorkingDirectory=/home/pi/homeeToMqtt
+WorkingDirectory=/home/n/homeeToMqtt
 User=pi
 #Group=<alternate group>
 Environment=NODE_ENV=production PORT=8000
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
Helllo!

I just added some options to make the integration wait for docker.service (optional) which is useful when mqtt is running inside a docker-container. Its commented out by default.

And then I changed the lines containing comments since there seems to be a bug in Systemd that prevents these lines from beeing read properly.